### PR TITLE
Minor changes to LLS gui and spec_widget

### DIFF
--- a/xastropy/xguis/spec_widgets.py
+++ b/xastropy/xguis/spec_widgets.py
@@ -146,11 +146,13 @@ class ExamineSpecWidget(QtGui.QWidget):
     # Setup the spectrum plotting info
     def init_spec(self):
         #xy min/max
-        xmin = np.min(self.spec.dispersion).value
-        xmax = np.max(self.spec.dispersion).value
-        ymed = np.median(self.spec.flux).value
-        ymin = 0. - 0.1*ymed
-        ymax = ymed * 1.5
+        xmin = np.min(self.spec.dispersion.value)
+        xmax = np.max(self.spec.dispersion.value)
+        from linetools.spectra.plotting import get_flux_plotrange
+        ymin, ymax = get_flux_plotrange(self.spec.flux.value, mult_pos=1)
+        # ymed = np.median(self.spec.flux.value)
+        # ymin = 0. - 0.1*ymed
+        # ymax = ymed * 1.5
         #
         #QtCore.pyqtRemoveInputHook()
         #xdb.set_trace()

--- a/xastropy/xguis/xfitllsgui.py
+++ b/xastropy/xguis/xfitllsgui.py
@@ -265,7 +265,8 @@ class XFitLLSGUI(QtGui.QMainWindow):
         # Point MainWindow
         self.setCentralWidget(self.main_widget)
 
-        self.spec_widg.setFixedWidth(900)
+        #self.spec_widg.setFixedWidth(900)
+        self.spec_widg.setMinimumWidth(900)
 
     def on_list_change(self):
         self.update_boxes()
@@ -462,6 +463,11 @@ class XFitLLSGUI(QtGui.QMainWindow):
         elif event.key in ['6','7','8','9']: # Add forest line
             self.add_forest(event.key,event.xdata/1215.6701 - 1.)
             self.update_model()
+        elif event.key == 'Q':
+            # set an attribute to tell calling script to abort
+            print("Setting the quit attribute, the calling script should "
+                  "abort after you close the GUI")
+            self.script_quit = True
         else:
             self.spec_widg.on_key(event)
 


### PR DESCRIPTION
This makes the spec_widget use get_flux_plotrange in linetools to guess the initial plotting limits, which deals with NaNs.

It also adds a hacky 'Q' option to the LLS gui so it can signal to a calling script that it should stop.