### PR TITLE
Add norm keyword to LLS gui

### DIFF
--- a/xastropy/xguis/xfitllsgui.py
+++ b/xastropy/xguis/xfitllsgui.py
@@ -87,7 +87,7 @@ class XFitLLSGUI(QtGui.QMainWindow):
     """
     def __init__(self, ispec, parent=None, lls_fit_file=None,
         outfil=None, smooth=3., zqso=None, fN_gamma=None, template=None,
-        dw=0.1, skip_wveval=False):
+        dw=0.1, skip_wveval=False, norm=True):
         QtGui.QMainWindow.__init__(self, parent)
         '''
         ispec : Spectrum1D or specfil
@@ -108,6 +108,9 @@ class XFitLLSGUI(QtGui.QMainWindow):
         skip_wveval : bool, optional
           Skip rebinning of wavelengths in the Voigt profile generation.
           This can speed up the code considerably, but use it wisely.
+        norm : bool, optional
+          Whether to normalize the spectrum by dividing by the
+          continuum (default True).
         '''
 
         # Build a widget combining several others
@@ -162,7 +165,8 @@ class XFitLLSGUI(QtGui.QMainWindow):
         self.spec_widg = ltgsp.ExamineSpecWidget(spec,status=self.statusBar,
                                            llist=self.llist, key_events=False,
                                            abs_sys=self.abssys_widg.abs_sys,
-                                           vlines=vlines, plotzero=1)
+                                           vlines=vlines, plotzero=1,
+                                                 norm=norm)
         # Initialize continuum (and LLS if from a file)
         if lls_fit_file is not None:
             self.init_LLS(lls_fit_file,spec)


### PR DESCRIPTION
After a recent change in the ExamineSpec widget, spectra are normalised by default using the LLS gui. This PR adds the keyword `norm` to the LLS gui class that enables you to set the normalisation.