### PR TITLE
Update to configparser for py3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser, RawConfigParser
+except ImportError:
+    from configparser import ConfigParser, RawConfigParser
+
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This is an update to the astropy affiliated packages setup.py script, which is needed for python 3 compatibility. For example, we made a similar change in astropy/astroplan#177 recently. 

This change was prompted by @jessicawerk's Pre-MAP research project.